### PR TITLE
Kulcstartojelszó funkció már nincs használatban

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -961,7 +961,7 @@ class Client
                 {
                     $this->writeCredentials($writer);
                     $writer->writeElement('eszamla', $this->stringifyBoolean($invoice->isElectronic));
-                    $writer->writeElement('kulcstartojelszo', '');
+                    //$writer->writeElement('kulcstartojelszo', '');
                     $writer->writeElement('szamlaLetoltes', $this->stringifyBoolean(false));
                     $writer->writeElement('szamlaLetoltesPld', 1);
                 }
@@ -1021,7 +1021,7 @@ class Client
                     {
                         $this->writeCredentials($writer);
                         $writer->writeElement('eszamla', $this->stringifyBoolean($invoice->isElectronic));
-                        $writer->writeElement('kulcstartojelszo', '');
+                        // $writer->writeElement('kulcstartojelszo', '');
                         $writer->writeElement('szamlaLetoltes', $this->stringifyBoolean(true));
                         $writer->writeElement('szamlaLetoltesPld', 1);
                     }


### PR DESCRIPTION
Teszt környezetben hibát dob az API, ugyanis szigorúbb az ellenőrzés és már nem engedélyezett a kulcstartojelszo mező.