### PR TITLE
Round gross price

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -752,7 +752,7 @@ class Client
                         : ($netUnitPrice * $quantity);
                     $grossPrice = isset($item['grossPrice'])
                         ? $item['grossPrice']
-                        : $netPrice * (1 + ($taxRate / 100));
+                        : round($netPrice * (1 + ($taxRate / 100)), 2);
                     $taxValue = isset($item['taxValue'])
                         ? $item['taxValue']
                         : ($grossPrice - $netPrice);
@@ -1248,7 +1248,7 @@ class Client
                     $taxRate = is_numeric($item['taxRate']) ? $item['taxRate'] : 0;
                     $quantity = $item['quantity'];
                     $netPrice = isset($item['netPrice']) ? $item['netPrice'] : ($netUnitPrice * $quantity);
-                    $grossPrice = isset($item['grossPrice']) ? $item['grossPrice'] : $netPrice * (1 + ($taxRate / 100));
+                    $grossPrice = isset($item['grossPrice']) ? $item['grossPrice'] : round($netPrice * (1 + ($taxRate / 100)), 2);
                     $taxValue = isset($item['taxValue']) ? $item['taxValue'] : ($grossPrice - $netPrice);
 
                     $writer->writeElement('netto', $this->commonCurrencyFormat($netPrice));


### PR DESCRIPTION
Belefutottunk egy olyan esetbe, hogy a nettó 7,87 euróba kerülő termék 27% áfával 9,9949 euró, amit a számlázz.hu már bruttó 10 euróra kerekített. Viszont ha 9,99 eurót küldünk fel, akkor jó lesz.
A stripe is így számol:
![image](https://github.com/user-attachments/assets/a70601e9-806e-4932-a03f-7d03c2001bcc)
